### PR TITLE
Fix: 1マスピースで上がった時のボーナススコア判定を修正

### DIFF
--- a/js/game-logic.js
+++ b/js/game-logic.js
@@ -328,8 +328,8 @@ function getScore(player) {
   const pieces = state.playerPieces[player];
   const remaining = pieces.filter(p => !p.used).reduce((sum, p) => sum + p.shape.length, 0);
   if (remaining === 0) {
-    const lastPiece = pieces[pieces.length - 1];
-    return lastPiece.shape.length === 1 ? 20 : 15;
+    const lastCells = state.lastPlacedCells[player];
+    return (lastCells && lastCells.length === 1) ? 20 : 15;
   }
   return -remaining;
 }

--- a/js/test-logic.js
+++ b/js/test-logic.js
@@ -76,7 +76,10 @@ async function runTests() {
     GL.setGameState(s);
     assert('all unused = -89', GL.getScore(0) === -89);
     s.playerPieces[0].forEach(p => p.used = true);
-    assert('all used = +15', GL.getScore(0) === 15);
+    s.lastPlacedCells[0] = [[0, 0], [0, 1]];
+    assert('all used, last piece >1 tile = +15', GL.getScore(0) === 15);
+    s.lastPlacedCells[0] = [[0, 0]];
+    assert('all used, last piece 1 tile = +20', GL.getScore(0) === 20);
   }
 
   section('hasValidMove');

--- a/test.html
+++ b/test.html
@@ -102,14 +102,17 @@ function placePiece(board, player, shape, br, bc) {
   });
 }
 
-function getScore(playerPieces, player) {
+function getScore(playerPieces, player, lastPlacedCells) {
   const pieces = playerPieces[player];
   let total = 0;
   pieces.forEach(p => {
     if (!p.used) total -= p.shape.length;
   });
   const allUsed = pieces.every(p => p.used);
-  if (allUsed) total += 15;
+  if (allUsed) {
+    const lastCells = lastPlacedCells && lastPlacedCells[player];
+    total += (lastCells && lastCells.length === 1) ? 20 : 15;
+  }
   return total;
 }
 
@@ -321,20 +324,26 @@ section('getScore (スコア計算)');
     [[0,1],[1,0],[1,1],[1,2],[2,1]],
   ];
 
+  const lpc = [[], [], [], []];
   const pp = [PIECE_SHAPES.map(s => ({ shape: s.map(c => [...c]), used: false }))];
-  assert('全ピース未使用 → -89点', getScore(pp, 0) === -89);
+  assert('全ピース未使用 → -89点', getScore(pp, 0, lpc) === -89);
 
-  // 全ピース使用済み
+  // 全ピース使用済み（最後が複数マスピース）
   const ppAll = [PIECE_SHAPES.map(s => ({ shape: s.map(c => [...c]), used: true }))];
-  assert('全ピース使用済み → +15点 (ボーナス)', getScore(ppAll, 0) === 15);
+  const lpcMulti = [[[0,0],[1,0]], [], [], []];
+  assert('全ピース使用済み(最後>1マス) → +15点', getScore(ppAll, 0, lpcMulti) === 15);
+
+  // 全ピース使用済み（最後が1マスピース）
+  const lpcSingle = [[[0,0]], [], [], []];
+  assert('全ピース使用済み(最後1マス) → +20点', getScore(ppAll, 0, lpcSingle) === 20);
 
   // 一部使用（1マスと2マスのみ使用、残り86マス未使用）
   const ppPartial = [PIECE_SHAPES.map((s, i) => ({ shape: s.map(c => [...c]), used: i < 2 }))];
-  assert('1マス+2マスのみ使用 → -86点', getScore(ppPartial, 0) === -86);
+  assert('1マス+2マスのみ使用 → -86点', getScore(ppPartial, 0, lpc) === -86);
 
   // 最後の1ピース（1マス）だけ未使用
   const ppAlmost = [PIECE_SHAPES.map((s, i) => ({ shape: s.map(c => [...c]), used: i > 0 }))];
-  assert('1マスピースだけ未使用 → -1点', getScore(ppAlmost, 0) === -1);
+  assert('1マスピースだけ未使用 → -1点', getScore(ppAlmost, 0, lpc) === -1);
 }
 
 // --- 回転＋配置の統合テスト ---


### PR DESCRIPTION
## Summary
- `getScore` が最後に置いたピースではなく、ピース配列の末尾要素を参照していたバグを修正
- `state.lastPlacedCells[player]` を使い、実際に最後に置いたピースのサイズで+15/+20を正しく判定するように変更
- テスト (`test-logic.js`, `test.html`) に1マスボーナスのテストケースを追加

## 詳細
### 変更前の問題
```js
const lastPiece = pieces[pieces.length - 1]; // ← 定義順の最後のピース（固定）
return lastPiece.shape.length === 1 ? 20 : 15;
```
ピース配列の最後の要素は常に同じピースを指すため、実際のプレイ順序に関係なくボーナス判定されていました。

### 変更後
```js
const lastCells = state.lastPlacedCells[player]; // ← 実際に最後に置いたピースのセル
return (lastCells && lastCells.length === 1) ? 20 : 15;
```

## スコアルール
| 条件 | 点数 |
|------|------|
| ピースが残っている | 残りマス × -1点 |
| 全ピース配置完了 | +15点 |
| 全ピース配置完了 & 最後が1マスピース | +20点 |

## Test plan
- [ ] `test.html` をブラウザで開き、全テストがPASSすることを確認
- [ ] 全ピース配置完了時、最後が1マスピースなら+20点と表示されることを確認
- [ ] 全ピース配置完了時、最後が1マス以外なら+15点と表示されることを確認

https://claude.ai/code/session_011V1cBBZZbXBhyjJzNeJQ7X