### PR TITLE
メインメニューをBATTLE/PUZZLE 2階層構造に再構成

### DIFF
--- a/index.html
+++ b/index.html
@@ -1736,7 +1736,8 @@ function quitToTitle() {
   document.querySelector('#start-screen > p').style.display = '';
   document.getElementById('main-menu').style.display = 'flex';
   document.getElementById('battle-menu').style.display = 'none';
-  hideOrderSelect();
+  document.getElementById('board-size-screen').style.display = 'none';
+  document.getElementById('order-select').style.display = 'none';
   document.getElementById('char-select').style.display = 'none';
   const save = loadGame();
   const continueBtn = document.getElementById('continue-btn');
@@ -1754,7 +1755,8 @@ function backToTitle() {
   document.querySelector('#start-screen > p').style.display = '';
   document.getElementById('main-menu').style.display = 'flex';
   document.getElementById('battle-menu').style.display = 'none';
-  hideOrderSelect();
+  document.getElementById('board-size-screen').style.display = 'none';
+  document.getElementById('order-select').style.display = 'none';
   document.getElementById('char-select').style.display = 'none';
 }
 


### PR DESCRIPTION
## Summary
- メインメニューの「1P vs CPU」「LOCAL 4P」を **BATTLE** サブメニューに統合
- 将来のパズルモード用に **PUZZLE** ボタンをプレースホルダーとして追加（Coming soon / disabled）
- メインメニューのボタン数は5つのまま維持
- タイトルに戻る際に全サブ画面（battle-menu, board-size-screen, order-select, char-select）を確実に非表示にする修正を含む

## 関連Issue
- Closes #64

## Test plan
- [ ] BATTLE → 1P vs CPU → ボードサイズ選択 → 対戦 → HOME でタイトルに戻り、メニューが正常表示されること
- [ ] BATTLE → LOCAL 4P → ボードサイズ選択 → 対戦 → HOME でタイトルに戻り、メニューが正常表示されること
- [ ] 各画面のBACKボタンが正しく前の画面に遷移すること
- [ ] PUZZLEボタンがdisabled状態で押せないこと
- [ ] CONTINUEボタン（セーブデータあり時）が正常に動作すること
- [ ] TUTORIALが正常に開始・終了できること

https://claude.ai/code/session_01Jj1PjdmPHxZwJL7YPVPiSn