### PR TITLE
fix: パズルモードのボードサイズ表示と再描画を修正 (#70)

### DIFF
--- a/index.html
+++ b/index.html
@@ -312,6 +312,7 @@ canvas#board { display: block; touch-action: none; }
 <div id="app" style="display:none;">
   <div id="header">
     <h1>KADO</h1>
+    <span id="board-size-label" style="display:none;font-size:10px;color:#888;font-family:'Orbitron',sans-serif;"></span>
     <span id="turn-indicator">● P1</span>
     <button id="score-btn">SCORE</button>
   </div>
@@ -1377,6 +1378,12 @@ function resumeGame() {
 
   document.getElementById('start-screen').style.display = 'none';
   document.getElementById('app').style.display = 'flex';
+
+  // Show board size label
+  const sizeLabel = document.getElementById('board-size-label');
+  sizeLabel.textContent = state.BOARD_SIZE + '×' + state.BOARD_SIZE;
+  sizeLabel.style.display = '';
+
   selectedPieceIdx = null;
   currentShape = null;
   ghostPos = null;
@@ -1641,6 +1648,11 @@ function startGame(mode) {
   document.getElementById('start-screen').style.display = 'none';
   document.getElementById('app').style.display = 'flex';
 
+  // Show board size label
+  const sizeLabel = document.getElementById('board-size-label');
+  sizeLabel.textContent = selectedBoardSize + '×' + selectedBoardSize;
+  sizeLabel.style.display = '';
+
   initGame();
 }
 
@@ -1656,6 +1668,10 @@ function initGame() {
 
   // Show puzzle intro overlay
   if (state.gameMode === 'puzzle') {
+    const piecesPerPlayer = state.playerPieces[0].length;
+    const totalPieces = piecesPerPlayer * 4;
+    document.getElementById('puzzle-intro-size').textContent =
+      state.BOARD_SIZE + '×' + state.BOARD_SIZE + ' board — ' + totalPieces + ' pieces (' + piecesPerPlayer + ' × 4 colors)';
     document.getElementById('puzzle-intro-overlay').classList.add('show');
     return;
   }
@@ -2241,6 +2257,8 @@ function setupEventListeners() {
   // Puzzle intro overlay
   document.getElementById('puzzle-intro-start-btn').addEventListener('click', function() {
     document.getElementById('puzzle-intro-overlay').classList.remove('show');
+    resizeBoard();
+    drawBoard();
   });
   document.getElementById('puzzle-intro-overlay').addEventListener('click', function() {}); // prevent click-through
   document.getElementById('puzzle-intro-box').addEventListener('click', function(e) { e.stopPropagation(); });
@@ -2267,6 +2285,7 @@ function setupEventListeners() {
 <div id="puzzle-intro-overlay">
   <div id="puzzle-intro-box">
     <h2>PERFECT PLACE</h2>
+    <p id="puzzle-intro-size" style="text-align:center;color:#e94560;font-size:13px;margin-bottom:8px;font-family:'Orbitron',sans-serif;letter-spacing:1px;"></p>
     <div id="puzzle-intro-content">
       <h3>OBJECTIVE</h3>
       <p>Place <b>all pieces of all 4 colors</b> on the board.</p>


### PR DESCRIPTION
- パズルイントロオーバーレイ非表示時にresizeBoard()を呼び出し、
  レイアウトタイミングによるボードサイズの不一致を防止
- パズルイントロ画面に選択したボードサイズとピース数を表示
- ゲーム画面ヘッダーにボードサイズラベルを追加（全モード共通）

https://claude.ai/code/session_01H3mwrFQMiN5UGP223RQkHU