### PR TITLE
特商法ページの運営責任者に実名を記載

### DIFF
--- a/legal.html
+++ b/legal.html
@@ -36,7 +36,7 @@ td:last-child { color: #ccc; }
     </tr>
     <tr>
       <td>運営責任者</td>
-      <td>請求があった場合には速やかに開示いたします</td>
+      <td>稲村 鉄平</td>
     </tr>
     <tr>
       <td>所在地</td>


### PR DESCRIPTION
Stripe要件に対応するため、運営責任者を「請求があった場合には速やかに開示いたします」から「稲村 鉄平」に変更。

https://claude.ai/code/session_01F472jmQ82fempRJUPSSCfy