### PR TITLE
Update domain references from kado-game.pages.dev to tetutetu214.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
 <meta property="og:url" content="https://tetutetu214.com/game/kado">
 <meta property="og:title" content="KADO — Free Browser Strategy Game">
 <meta property="og:description" content="A free Blokus-inspired strategy game playable instantly in your browser. No download, no login. Play solo vs AI or local 4-player!">
-<meta property="og:image" content="https://kado-game.pages.dev/ogp.png">
+<meta property="og:image" content="https://tetutetu214.com/game/kado/ogp.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta property="og:locale" content="en_US">
@@ -38,7 +38,7 @@
 <meta name="twitter:url" content="https://tetutetu214.com/game/kado">
 <meta name="twitter:title" content="KADO — Free Browser Strategy Game">
 <meta name="twitter:description" content="A free Blokus-inspired strategy game playable instantly in your browser. No download, no login. Play solo vs AI or local 4-player!">
-<meta name="twitter:image" content="https://kado-game.pages.dev/ogp.png">
+<meta name="twitter:image" content="https://tetutetu214.com/game/kado/ogp.png">
 
 <!-- JSON-LD Structured Data -->
 <script type="application/ld+json">

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://kado-game.pages.dev/sitemap.xml
+Sitemap: https://tetutetu214.com/game/kado/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,4 +6,16 @@
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url>
+    <loc>https://tetutetu214.com/game/kado/puzzle</loc>
+    <lastmod>2026-03-31</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://tetutetu214.com/game/kado/legal</loc>
+    <lastmod>2026-03-31</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.3</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
This PR updates all domain references across the project from the old `kado-game.pages.dev` domain to the new primary domain `tetutetu214.com/game/kado`. This appears to be a domain migration or consolidation effort.

## Key Changes
- **sitemap.xml**: Added two new URL entries for the puzzle and legal pages with appropriate metadata (lastmod dates, change frequency, and priority levels)
- **index.html**: Updated Open Graph and Twitter Card meta tags to point to the new domain for the OGP image asset
- **robots.txt**: Updated the sitemap URL reference to use the new domain structure

## Notable Details
- The new sitemap includes proper SEO metadata:
  - Puzzle page: weekly changefreq, 0.8 priority
  - Legal page: monthly changefreq, 0.3 priority
- All image assets now resolve from `tetutetu214.com/game/kado/ogp.png` instead of the old CDN
- The domain migration maintains the same URL structure and SEO properties

https://claude.ai/code/session_01VHUYbRCaqifxQFchmm7pWv