### PR TITLE
fix: Web Worker未終了メモリリークを修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -666,14 +666,16 @@ function flipPiece() {
 var cpuWorker = null;
 var workerFailed = false;
 
-try {
-  cpuWorker = new Worker('./js/worker.js');
-} catch(e) {
-  console.warn('Worker creation failed, using main thread fallback:', e);
-  workerFailed = true;
-}
+function initWorker() {
+  if (cpuWorker) return;
+  try {
+    cpuWorker = new Worker('./js/worker.js');
+  } catch(e) {
+    console.warn('Worker creation failed, using main thread fallback:', e);
+    workerFailed = true;
+    return;
+  }
 
-if (cpuWorker) {
   cpuWorker.onmessage = function(e) {
     var move = e.data;
     if (move) {
@@ -705,6 +707,17 @@ if (cpuWorker) {
     }
   };
 }
+
+function cleanupWorker() {
+  if (cpuWorker) {
+    cpuWorker.terminate();
+    cpuWorker = null;
+  }
+}
+
+initWorker();
+
+window.addEventListener('beforeunload', cleanupWorker);
 
 function cpuMoveFallback() {
   var ch = getCpuCharacter(state.currentPlayer);
@@ -1862,6 +1875,7 @@ function confirmBoardSize(size) {
 }
 
 function startGame(mode) {
+  initWorker();
   state.BOARD_SIZE = selectedBoardSize;
   deleteSave(); // Clear old save when starting new game
   // For continuous mode, use 'cpu' internally for game logic
@@ -2137,6 +2151,7 @@ function quitToTitle() {
     endTutorial();
     return;
   }
+  cleanupWorker();
   if (!state.gameOver) {
     saveGame();
   }


### PR DESCRIPTION
## Summary
- CPU AI用Web Workerが`terminate()`されずメモリリークしていた問題を修正
- Worker初期化を`initWorker()`、終了を`cleanupWorker()`に分離
- HOMEボタン(`quitToTitle`)でWorkerを終了し、`startGame`で再生成するライフサイクルを実装
- `beforeunload`イベントでページ離脱時にもWorkerを確実に終了

## Test plan
- [ ] CPUモードでゲームを開始し、HOMEボタンで戻った後、再度ゲーム開始してCPUが正常に動作すること
- [ ] モード切替を繰り返してもメモリ使用量が増加し続けないこと
- [ ] Worker生成失敗時のフォールバック（メインスレッド実行）が引き続き動作すること
- [ ] ページリロード・離脱時にエラーが発生しないこと

Closes #84

https://claude.ai/code/session_01PNYcsoAbduAxQKdGu7Czu4