### PR TITLE
fix: localStorage容量超過時にユーザーへトースト通知を表示

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,6 +182,7 @@ canvas#board { display: block; touch-action: none; }
 #cpu-thinking { display: none; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); background: rgba(0,0,0,0.9); color: #e94560; padding: 12px 24px; border-radius: 4px; font-size: 14px; z-index: 50; border: 1px solid rgba(233,69,96,0.3); letter-spacing: 2px; }
 #auto-pass-toast { display: none; position: absolute; top: 40%; left: 50%; transform: translate(-50%, -50%); background: rgba(0,0,0,0.85); color: #fff; padding: 14px 28px; border-radius: 14px; font-size: 15px; z-index: 60; text-align: center; animation: fadeInOut 2s ease-in-out; pointer-events: none; }
 #auto-pass-toast .pass-name { font-weight: bold; font-size: 17px; }
+#save-error-toast { display: none; position: fixed; top: 20%; left: 50%; transform: translate(-50%, -50%); background: rgba(180,40,60,0.95); color: #fff; padding: 14px 28px; border-radius: 14px; font-size: 14px; z-index: 9999; text-align: center; pointer-events: none; }
 @keyframes fadeInOut { 0% { opacity: 0; transform: translate(-50%,-50%) scale(0.8); } 15% { opacity: 1; transform: translate(-50%,-50%) scale(1); } 75% { opacity: 1; } 100% { opacity: 0; } }
 #battle-menu, #puzzle-menu { flex-direction: column; align-items: center; gap: 16px; }
 #battle-menu h2, #puzzle-menu h2 { font-family: 'Press Start 2P', monospace; font-size: 16px; letter-spacing: 2px; }
@@ -367,6 +368,7 @@ canvas#board { display: block; touch-action: none; }
       <div id="auto-pass-toast"><span class="pass-name"></span><br>No valid moves - AUTO PASS</div>
     </div>
   </div>
+  <div id="save-error-toast">Save failed - storage full</div>
   <div id="piece-panel">
     <div id="piece-controls">
       <button id="rotate-btn" class="icon-btn">↻</button>
@@ -1010,6 +1012,16 @@ function handleBoardTap(pos) {
   // Do NOT deselect on invalid placement - keep piece selected so user can try again
 }
 
+// ===== Save Error Toast =====
+function showSaveErrorToast() {
+  var toast = document.getElementById('save-error-toast');
+  toast.style.display = 'block';
+  toast.style.animation = 'none';
+  toast.offsetHeight;
+  toast.style.animation = 'fadeInOut 3s ease-in-out';
+  setTimeout(function() { toast.style.display = 'none'; }, 3000);
+}
+
 // ===== Auto Pass =====
 function showAutoPassToast(player, callback) {
   const toast = document.getElementById('auto-pass-toast');
@@ -1515,6 +1527,7 @@ function saveGame() {
     localStorage.setItem('kado_save', JSON.stringify(saveData));
   } catch(e) {
     console.warn('Save failed:', e);
+    showSaveErrorToast();
   }
 }
 
@@ -1967,6 +1980,7 @@ function saveStats(stats) {
     localStorage.setItem('kado_stats', JSON.stringify(stats));
   } catch(e) {
     console.warn('Stats save failed:', e);
+    showSaveErrorToast();
   }
 }
 

--- a/puzzle/index.html
+++ b/puzzle/index.html
@@ -72,6 +72,7 @@ canvas#board { display: block; touch-action: none; }
 /* No valid moves toast */
 #no-moves-toast { display: none; position: absolute; top: 40%; left: 50%; transform: translate(-50%, -50%); background: rgba(180,40,60,0.95); color: #fff; padding: 14px 28px; border-radius: 14px; font-size: 13px; z-index: 60; text-align: center; font-family: -apple-system, BlinkMacSystemFont, sans-serif; animation: fadeInOut 2.5s ease-in-out; pointer-events: none; }
 @keyframes fadeInOut { 0% { opacity: 0; transform: translate(-50%,-50%) scale(0.8); } 15% { opacity: 1; transform: translate(-50%,-50%) scale(1); } 75% { opacity: 1; } 100% { opacity: 0; } }
+#save-error-toast { display: none; position: fixed; top: 20%; left: 50%; transform: translate(-50%, -50%); background: rgba(180,40,60,0.95); color: #fff; padding: 14px 28px; border-radius: 14px; font-size: 14px; z-index: 9999; text-align: center; pointer-events: none; }
 </style>
 </head>
 <body>
@@ -86,6 +87,7 @@ canvas#board { display: block; touch-action: none; }
     <canvas id="board"></canvas>
     <div id="no-moves-toast"></div>
   </div>
+  <div id="save-error-toast">Save failed - storage full</div>
   <div id="color-selector"></div>
   <div id="piece-panel">
     <div id="piece-controls">
@@ -185,6 +187,16 @@ function getAllOrientations(shape) {
     s = flipH(shape.map(function(c) { return [c[0], c[1]]; }));
   }
   return orientations;
+}
+
+// ===== Save Error Toast =====
+function showSaveErrorToast() {
+  var toast = document.getElementById('save-error-toast');
+  toast.style.display = 'block';
+  toast.style.animation = 'none';
+  toast.offsetHeight;
+  toast.style.animation = 'fadeInOut 3s ease-in-out';
+  setTimeout(function() { toast.style.display = 'none'; }, 3000);
 }
 
 // ===== Game State =====
@@ -723,7 +735,10 @@ function showClear() {
       var bSec = parseInt(best) % 60;
       document.getElementById('clear-time').textContent += ' (BEST: ' + bMin + ':' + (bSec < 10 ? '0' : '') + bSec + ')';
     }
-  } catch(e) {}
+  } catch(e) {
+    console.warn('Best time save failed:', e);
+    showSaveErrorToast();
+  }
 
   document.getElementById('clear-overlay').classList.add('show');
 }


### PR DESCRIPTION
## Summary
- `localStorage.setItem()` の失敗が catch で黙殺されていた問題を修正
- セーブ失敗時に「Save failed - storage full」トーストを3秒間表示するようにした
- 対象: `index.html`（ゲームセーブ・戦績保存）、`puzzle/index.html`（ベストタイム保存）

## Test plan
- [ ] Cloudflare Pagesのプレビューで動作確認
- [ ] DevToolsでlocalStorageを満杯にした状態でセーブ操作を行い、トーストが表示されることを確認
- [ ] トーストが3秒後に自動で消えることを確認
- [ ] 通常のセーブ操作時にトーストが表示されないことを確認

Closes #88

https://claude.ai/code/session_019Eth3rZRhx8x596v5yp9Hh