### PR TITLE
feat: Retina/高DPIディスプレイ対応（Canvas解像度スケーリング）

### DIFF
--- a/index.html
+++ b/index.html
@@ -524,16 +524,19 @@ function resizeBoard() {
   const available = Math.min(container.clientWidth, container.clientHeight) - 8;
   cellSize = Math.floor(available / state.BOARD_SIZE);
   const size = cellSize * state.BOARD_SIZE;
-  canvas.width = size;
-  canvas.height = size;
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = size * dpr;
+  canvas.height = size * dpr;
   canvas.style.width = size + 'px';
   canvas.style.height = size + 'px';
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   drawBoard();
 }
 
 // ===== Board Drawing =====
 function drawBoard() {
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const logicalW = cellSize * state.BOARD_SIZE;
+  ctx.clearRect(0, 0, logicalW, logicalW);
 
   for (let r = 0; r < state.BOARD_SIZE; r++) {
     for (let c = 0; c < state.BOARD_SIZE; c++) {
@@ -804,9 +807,15 @@ function updatePieceList() {
     const maxC = Math.max(...shape.map(s => s[1])) + 1;
     const cs = Math.min(20, Math.floor(60 / Math.max(maxR, maxC)));
     const cvs = document.createElement('canvas');
-    cvs.width = maxC * cs + 2;
-    cvs.height = maxR * cs + 2;
+    const dpr = window.devicePixelRatio || 1;
+    const lw = maxC * cs + 2;
+    const lh = maxR * cs + 2;
+    cvs.width = lw * dpr;
+    cvs.height = lh * dpr;
+    cvs.style.width = lw + 'px';
+    cvs.style.height = lh + 'px';
     const cx = cvs.getContext('2d');
+    cx.scale(dpr, dpr);
     shape.forEach(([r, c]) => {
       cx.fillStyle = players[state.currentPlayer].color;
       cx.fillRect(c * cs + 1, r * cs + 1, cs - 1, cs - 1);
@@ -1202,9 +1211,15 @@ function showPlayerPieces(playerIdx) {
     const maxC = Math.max(...shape.map(s => s[1])) + 1;
     const cs = Math.min(20, Math.floor(60 / Math.max(maxR, maxC)));
     const cvs = document.createElement('canvas');
-    cvs.width = maxC * cs + 2;
-    cvs.height = maxR * cs + 2;
+    const dpr = window.devicePixelRatio || 1;
+    const lw = maxC * cs + 2;
+    const lh = maxR * cs + 2;
+    cvs.width = lw * dpr;
+    cvs.height = lh * dpr;
+    cvs.style.width = lw + 'px';
+    cvs.style.height = lh + 'px';
     const cx = cvs.getContext('2d');
+    cx.scale(dpr, dpr);
     shape.forEach(([r, c]) => {
       cx.fillStyle = players[playerIdx].color;
       cx.fillRect(c * cs + 1, r * cs + 1, cs - 1, cs - 1);
@@ -2090,10 +2105,12 @@ function showStats() {
     leftCol.appendChild(title);
     var cvs = document.createElement('canvas');
     var w = 300, h = 120;
-    cvs.width = w; cvs.height = h;
+    var dpr = window.devicePixelRatio || 1;
+    cvs.width = w * dpr; cvs.height = h * dpr;
     cvs.style.cssText = 'width:100%;max-width:300px;margin:4px auto;display:block;';
     leftCol.appendChild(cvs);
     var gctx = cvs.getContext('2d');
+    gctx.scale(dpr, dpr);
     var hist = stats.history;
     var padL = 30, padR = 15, padT = 15, padB = 25;
     var chartW = w - padL - padR, chartH = h - padT - padB;

--- a/puzzle/index.html
+++ b/puzzle/index.html
@@ -331,15 +331,21 @@ function resizeBoard() {
   var csW = Math.floor(availW / COLS);
   var csH = Math.floor(availH / ROWS);
   cellSize = Math.min(csW, csH);
-  canvas.width = cellSize * COLS;
-  canvas.height = cellSize * ROWS;
-  canvas.style.width = canvas.width + 'px';
-  canvas.style.height = canvas.height + 'px';
+  var logicalW = cellSize * COLS;
+  var logicalH = cellSize * ROWS;
+  var dpr = window.devicePixelRatio || 1;
+  canvas.width = logicalW * dpr;
+  canvas.height = logicalH * dpr;
+  canvas.style.width = logicalW + 'px';
+  canvas.style.height = logicalH + 'px';
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   drawBoard();
 }
 
 function drawBoard() {
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  var logicalW = cellSize * COLS;
+  var logicalH = cellSize * ROWS;
+  ctx.clearRect(0, 0, logicalW, logicalH);
 
   for (var r = 0; r < ROWS; r++) {
     for (var c = 0; c < COLS; c++) {
@@ -488,9 +494,15 @@ function updatePieceList() {
       var maxC = Math.max.apply(null, shape.map(function(s) { return s[1]; })) + 1;
       var cs = Math.min(20, Math.floor(60 / Math.max(maxR, maxC)));
       var cvs = document.createElement('canvas');
-      cvs.width = maxC * cs + 2;
-      cvs.height = maxR * cs + 2;
+      var dpr = window.devicePixelRatio || 1;
+      var lw = maxC * cs + 2;
+      var lh = maxR * cs + 2;
+      cvs.width = lw * dpr;
+      cvs.height = lh * dpr;
+      cvs.style.width = lw + 'px';
+      cvs.style.height = lh + 'px';
       var cx = cvs.getContext('2d');
+      cx.scale(dpr, dpr);
       shape.forEach(function(s) {
         cx.fillStyle = COLORS[activeColor].color;
         cx.fillRect(s[1] * cs + 1, s[0] * cs + 1, cs - 1, cs - 1);


### PR DESCRIPTION
## Summary
- `devicePixelRatio` を考慮してCanvas内部解像度をスケーリングし、高DPI環境（Retina Mac、スマートフォン2x-3x DPI）での描画ボケを解消
- メインボード、ピースリスト、統計グラフ、パズルモードの全Canvasに適用
- キャラクターピクセルアート（16x16）は `image-rendering: pixelated` で意図的なドット絵表示のため対象外

## 変更内容
- `index.html`: メインボードCanvas、ピースリストCanvas(2箇所)、統計グラフCanvasにDPRスケーリング追加
- `puzzle/index.html`: パズルボードCanvas、パズルピースリストCanvasにDPRスケーリング追加

## Test plan
- [x] 統合テスト 79/79 合格（`node test.js`）
- [ ] Retina Mac / 高DPIスマートフォンでボード描画がシャープになることを目視確認
- [ ] 通常DPI（1x）環境で表示が崩れないことを確認
- [ ] パズルモードのボード・ピース表示を確認
- [ ] 統計画面のLast 10 Gamesグラフ表示を確認

Closes #81

https://claude.ai/code/session_01EzKhSm7YPiMdX5HjoUptLJ