### PR TITLE
fix: add Node.js exports to game-logic.js so unit tests pass (#96)

### DIFF
--- a/js/game-logic.js
+++ b/js/game-logic.js
@@ -406,3 +406,15 @@ function hasValidMove(player) {
   }
   return false;
 }
+
+// Node.js exports (for tests). No-op when loaded via <script> or importScripts.
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    PIECE_SHAPES, PIECES_14, PIECES_24,
+    rotateCW, flipH, normalize, getAllOrientations,
+    isFirstMove, getStartCorner, canPlace, placePiece,
+    getScore, hasValidMove, cpuMove, setGameState,
+    initState, restoreState, state,
+    getCornerPositions, countNewCorners, countBlockedOpponentCorners, getCenterDistance,
+  };
+}

--- a/js/test-logic.js
+++ b/js/test-logic.js
@@ -9,7 +9,7 @@ function assert(name, condition) {
 function section(name) { console.log('\n\x1b[33m' + name + '\x1b[0m'); }
 
 async function runTests() {
-  const GL = await import('./game-logic.js');
+  const GL = require('./game-logic.js');
 
   // Setup a mock state
   function makeState(boardSize) {


### PR DESCRIPTION
## Summary
- `game-logic.js` にConditional CommonJS exports を追加し、Node.js 環境でのモジュール読み込みに対応
- `test-logic.js` の `await import()` を `require()` に変更
- ブラウザ (`<script>`) や Web Worker (`importScripts`) での動作には影響なし

## Test plan
- [x] `node js/test-logic.js` — 全33テスト合格
- [x] `node test.js` — 全79テスト合格

Closes #96

https://claude.ai/code/session_01LHogg3L57eWRGBW1FUkY2W