### PR TITLE
feat: 分割ページの prefetch リンクを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,9 @@
 <meta name="twitter:description" content="A free Blokus-inspired strategy game playable instantly in your browser. No download, no login. Play solo vs AI or local 4-player!">
 <meta name="twitter:image" content="https://tetutetu214.com/game/kado/ogp.png">
 
+<!-- Prefetch split pages for faster navigation -->
+<link rel="prefetch" href="/puzzle/">
+
 <!-- JSON-LD Structured Data -->
 <script type="application/ld+json">
 {


### PR DESCRIPTION
## Summary
- `index.html` の `<head>` に `<link rel="prefetch" href="/puzzle/">` を追加
- ブラウザがアイドル時間に puzzle ページをバックグラウンドで先読みし、遷移を高速化

## Test plan
- [ ] DevTools Network タブで puzzle/ が prefetch されていることを確認
- [ ] 既存の全機能（BATTLE / PUZZLE / チュートリアル）が正常に動作すること

Closes #103

https://claude.ai/code/session_0119cRBPhAyAPXymsxankXzm