### PR TITLE
feat: startViewTransition をゲーム開始系に追加

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1226,26 +1226,26 @@ function resumeGame() {
   withViewTransition(() => {
     document.getElementById('start-screen').style.display = 'none';
     document.getElementById('app').style.display = 'flex';
+
+    // Show board size label
+    const sizeLabel = document.getElementById('board-size-label');
+    sizeLabel.textContent = state.BOARD_SIZE + '×' + state.BOARD_SIZE;
+    sizeLabel.style.display = '';
+
+    selectedPieceIdx = null;
+    currentShape = null;
+    ghostPos = null;
+    cpuThinking = false;
+    updateRoundIndicator();
+    updateTurnIndicator();
+    resizeBoard();
+    updatePieceList();
+
+    // If it's CPU's turn, auto-play
+    if (isCpuPlayer(state.currentPlayer) && !state.gameOver) {
+      setTimeout(executeCpuTurn, 500);
+    }
   });
-
-  // Show board size label
-  const sizeLabel = document.getElementById('board-size-label');
-  sizeLabel.textContent = state.BOARD_SIZE + '×' + state.BOARD_SIZE;
-  sizeLabel.style.display = '';
-
-  selectedPieceIdx = null;
-  currentShape = null;
-  ghostPos = null;
-  cpuThinking = false;
-  updateRoundIndicator();
-  updateTurnIndicator();
-  resizeBoard();
-  updatePieceList();
-
-  // If it's CPU's turn, auto-play
-  if (isCpuPlayer(state.currentPlayer) && !state.gameOver) {
-    setTimeout(executeCpuTurn, 500);
-  }
 }
 
 function updateContinueButton() {
@@ -1554,18 +1554,18 @@ function startGame(mode) {
   withViewTransition(() => {
     document.getElementById('start-screen').style.display = 'none';
     document.getElementById('app').style.display = 'flex';
+
+    if (continuousMode) {
+      updateRoundIndicator();
+    }
+
+    // Show board size label
+    const sizeLabel = document.getElementById('board-size-label');
+    sizeLabel.textContent = selectedBoardSize + '×' + selectedBoardSize;
+    sizeLabel.style.display = '';
+
+    initGame();
   });
-
-  if (continuousMode) {
-    updateRoundIndicator();
-  }
-
-  // Show board size label
-  const sizeLabel = document.getElementById('board-size-label');
-  sizeLabel.textContent = selectedBoardSize + '×' + selectedBoardSize;
-  sizeLabel.style.display = '';
-
-  initGame();
 }
 
 function initGame() {


### PR DESCRIPTION
## Summary
- `withViewTransition()` ヘルパー関数を追加（非対応ブラウザではフォールバック）
- `startGame()` と `resumeGame()` の画面切り替えにcrossfadeアニメーションを適用

## Test plan
- [ ] CPU戦、ローカル対戦、パズルモード、連続対戦の各開始が正常に動くこと
- [ ] セーブからの再開が正常に動くこと
- [ ] 画面遷移時にクロスフェードアニメーションが表示されること

Closes #106

https://claude.ai/code/session_0119cRBPhAyAPXymsxankXzm