### PR TITLE
feat: startViewTransition をタイトル戻り系に追加

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1803,20 +1803,22 @@ function quitToTitle() {
   if (!state.gameOver) {
     saveGame();
   }
-  document.getElementById('app').style.display = 'none';
-  document.getElementById('start-screen').style.display = 'flex';
-  document.querySelector('#start-screen > h1').style.display = '';
-  document.querySelector('#start-screen > p').style.display = '';
-  document.getElementById('main-menu').style.display = 'flex';
-  document.getElementById('battle-menu').style.display = 'none';
-  document.getElementById('puzzle-menu').style.display = 'none';
-  document.getElementById('board-size-screen').style.display = 'none';
-  document.getElementById('order-select').style.display = 'none';
-  document.getElementById('char-select').style.display = 'none';
-  document.getElementById('round-select').style.display = 'none';
-  const save = loadGame();
-  const continueBtn = document.getElementById('continue-btn');
-  if (continueBtn) continueBtn.style.display = save ? 'inline-block' : 'none';
+  withViewTransition(() => {
+    document.getElementById('app').style.display = 'none';
+    document.getElementById('start-screen').style.display = 'flex';
+    document.querySelector('#start-screen > h1').style.display = '';
+    document.querySelector('#start-screen > p').style.display = '';
+    document.getElementById('main-menu').style.display = 'flex';
+    document.getElementById('battle-menu').style.display = 'none';
+    document.getElementById('puzzle-menu').style.display = 'none';
+    document.getElementById('board-size-screen').style.display = 'none';
+    document.getElementById('order-select').style.display = 'none';
+    document.getElementById('char-select').style.display = 'none';
+    document.getElementById('round-select').style.display = 'none';
+    const save = loadGame();
+    const continueBtn = document.getElementById('continue-btn');
+    if (continueBtn) continueBtn.style.display = save ? 'inline-block' : 'none';
+  });
 }
 
 function backToTitle() {
@@ -1825,17 +1827,19 @@ function backToTitle() {
   document.getElementById('modal-close-btn').style.display = '';
   deleteSave();
   resetContinuousState();
-  document.getElementById('app').style.display = 'none';
-  document.getElementById('start-screen').style.display = 'flex';
-  document.querySelector('#start-screen > h1').style.display = '';
-  document.querySelector('#start-screen > p').style.display = '';
-  document.getElementById('main-menu').style.display = 'flex';
-  document.getElementById('battle-menu').style.display = 'none';
-  document.getElementById('puzzle-menu').style.display = 'none';
-  document.getElementById('board-size-screen').style.display = 'none';
-  document.getElementById('order-select').style.display = 'none';
-  document.getElementById('char-select').style.display = 'none';
-  document.getElementById('round-select').style.display = 'none';
+  withViewTransition(() => {
+    document.getElementById('app').style.display = 'none';
+    document.getElementById('start-screen').style.display = 'flex';
+    document.querySelector('#start-screen > h1').style.display = '';
+    document.querySelector('#start-screen > p').style.display = '';
+    document.getElementById('main-menu').style.display = 'flex';
+    document.getElementById('battle-menu').style.display = 'none';
+    document.getElementById('puzzle-menu').style.display = 'none';
+    document.getElementById('board-size-screen').style.display = 'none';
+    document.getElementById('order-select').style.display = 'none';
+    document.getElementById('char-select').style.display = 'none';
+    document.getElementById('round-select').style.display = 'none';
+  });
 }
 
 let resizeTimeout;


### PR DESCRIPTION
## Summary
- `quitToTitle()` と `backToTitle()` の画面切り替えにcrossfadeアニメーションを適用
- Step 4 と同じパターンで、全DOM変更をコールバック内に配置

## Test plan
- [ ] ゲーム中の「戻る」操作でタイトルに戻れること
- [ ] 結果画面からの「タイトルへ」が正常に動くこと
- [ ] セーブデータが正しく保持されること（quitToTitle）
- [ ] クロスフェードアニメーションが表示されること

Closes #107

https://claude.ai/code/session_0119cRBPhAyAPXymsxankXzm