### PR TITLE
feat: キャラクターステータスを5段階化し、選択画面にステータス表示を追加 (#130)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -93,8 +93,9 @@ canvas#board { display: block; touch-action: none; }
 #order-select h2, #difficulty-select h2, #char-select h2 { font-size: 16px; margin-bottom: 4px; }
 #order-select p, #difficulty-select p, #char-select p { font-size: 12px; color: #aaa; }
 #char-select .char-slot-label { font-size: 14px; font-weight: bold; margin-top: 4px; }
-#char-select .char-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px; width: 95vw; max-width: 450px; }
+#char-select .char-grid { display: grid; grid-template-columns: auto repeat(3, 1fr); gap: 6px; width: 95vw; max-width: 500px; }
 #char-select .char-grid-header { font-size: 11px; font-weight: bold; color: #e94560; text-align: center; padding: 2px 0; letter-spacing: 2px; }
+#char-select .char-grid-tier { font-size: 10px; font-weight: bold; color: #888; writing-mode: vertical-rl; text-orientation: mixed; display: flex; align-items: center; justify-content: center; letter-spacing: 1px; }
 #char-select .char-card .char-name { font-size: 11px; white-space: nowrap; }
 #char-select .char-card { background: rgba(15,52,96,0.4); border: 1px solid rgba(233,69,96,0.2); border-radius: 4px; padding: 8px 6px; text-align: center; cursor: pointer; touch-action: manipulation; transition: all 0.2s; }
 #char-select .char-card:hover { background: rgba(15,52,96,0.7); border-color: rgba(233,69,96,0.6); box-shadow: 0 0 15px rgba(233,69,96,0.2); }
@@ -111,12 +112,12 @@ canvas#board { display: block; touch-action: none; }
 #char-select .char-card .char-tooltip-name { font-size: 13px; font-weight: bold; color: #fff; margin-bottom: 2px; }
 #char-select .char-card .char-tooltip-caption { font-size: 10px; color: #aaa; font-style: italic; margin-bottom: 6px; }
 #char-select .char-card .char-stat-row { display: flex; align-items: center; gap: 6px; font-size: 10px; line-height: 1.6; }
-#char-select .char-card .char-stat-label { color: #888; width: 28px; text-align: right; font-weight: bold; }
+#char-select .char-card .char-stat-label { color: #888; width: 52px; text-align: right; font-weight: bold; }
 #char-select .char-card .char-stat-dots { letter-spacing: 1px; }
 #char-select .char-card .char-stat-filled { color: #e94560; }
 #char-select .char-card .char-stat-empty { color: #333; }
 #char-select .char-card.selected .char-stat-row { font-size: 10px; line-height: 1.6; display: flex; align-items: center; gap: 6px; }
-#char-select .char-card.selected .char-stat-label { color: #888; width: 28px; text-align: right; font-weight: bold; }
+#char-select .char-card.selected .char-stat-label { color: #888; width: 52px; text-align: right; font-weight: bold; }
 #char-select .char-card.selected .char-stat-filled { color: #e94560; }
 #char-select .char-card.selected .char-stat-empty { color: #333; }
 .order-btn { background: transparent; border: 1px solid rgba(233,69,96,0.3); color: #eee; padding: 12px 24px; border-radius: 4px; font-size: 14px; cursor: pointer; width: 220px; text-align: center; touch-action: manipulation; letter-spacing: 1px; transition: all 0.2s; }

--- a/js/main.js
+++ b/js/main.js
@@ -1377,22 +1377,30 @@ function renderCharSelect() {
 
   const grid = document.getElementById('char-grid');
   grid.innerHTML = '';
-  grid.style.gridTemplateColumns = 'repeat(3, 1fr)';
-  // Column headers
-  var colHeaders = ['ATK', 'DEF', 'RNG'];
+  grid.style.gridTemplateColumns = 'auto repeat(3, 1fr)';
+  // Column headers (empty corner + 3 playstyle labels)
+  var corner = document.createElement('div');
+  corner.className = 'char-grid-header';
+  grid.appendChild(corner);
+  var colHeaders = ['ATK', 'DEF', 'RANDOM'];
   colHeaders.forEach(function(h) {
     var hdr = document.createElement('div');
     hdr.className = 'char-grid-header';
     hdr.textContent = h;
     grid.appendChild(hdr);
   });
-  // Grid layout: rows = Tier (strong→weak), cols = playstyle (ATK, DEF, RNG)
-  var gridOrder = [
-    0, 1, 2,  // Tier1: BLAZE, AEGIS, CHAOS
-    3, 4, 5,  // Tier2: SPIKE, PROXY, GLITCH
-    6, 7, 8   // Tier3: EMBER, ECHO, FLICKER
+  // Grid layout: rows = Tier (strong→weak), cols = playstyle (ATK, DEF, RANDOM)
+  var tiers = [
+    { label: 'Tier1', chars: [0, 1, 2] },
+    { label: 'Tier2', chars: [3, 4, 5] },
+    { label: 'Tier3', chars: [6, 7, 8] }
   ];
-  gridOrder.forEach(function(i) {
+  tiers.forEach(function(tier) {
+    var rowLabel = document.createElement('div');
+    rowLabel.className = 'char-grid-tier';
+    rowLabel.textContent = tier.label;
+    grid.appendChild(rowLabel);
+    tier.chars.forEach(function(i) {
     var ch = CPU_CHARACTERS[i];
     const card = document.createElement('div');
     card.className = 'char-card';
@@ -1412,7 +1420,7 @@ function renderCharSelect() {
       '<div class="char-tooltip-caption">"' + ch.caption + '"</div>' +
       buildStatBar('ATK', ch.atk) +
       buildStatBar('DEF', ch.def) +
-      buildStatBar('RNG', ch.rng);
+      buildStatBar('RANDOM', ch.rng);
     card.appendChild(tooltip);
     drawCharPixelArt(cvs, ch.id);
     // Long-press shows tooltip on mobile, short tap selects
@@ -1439,6 +1447,7 @@ function renderCharSelect() {
     }, { passive: true });
     card.onclick = function() { if (!longPressed) pickCharacter(i); };
     grid.appendChild(card);
+    });
   });
 }
 
@@ -1472,7 +1481,7 @@ function pickCharacter(charIdx) {
         '<span class="char-caption">' + ch.caption + '</span>' +
         buildStatBar('ATK', ch.atk) +
         buildStatBar('DEF', ch.def) +
-        buildStatBar('RNG', ch.rng);
+        buildStatBar('RANDOM', ch.rng);
       card.appendChild(info);
       drawCharPixelArt(cvs, ch.id);
       grid.appendChild(card);


### PR DESCRIPTION
## Summary
- キャラクターのATK/DEF/RNGステータスを0-3から0-5の5段階に拡張し、各キャラの個性をより明確に
- キャラ選択画面でホバー時にATK/DEF/RNGのドットバー付きツールチップを表示
- モバイルでは長押しでツールチップ表示に対応
- captionテキストをカードに常時表示
- 選択完了サマリー画面にもステータスバーを直接表示

## Test plan
- [ ] キャラ選択画面で各キャラにホバーしてツールチップが表示されることを確認
- [ ] ツールチップのATK/DEF/RNGドット数が各キャラの設定値と一致することを確認
- [ ] モバイルで長押しによるツールチップ表示・短タップでのキャラ選択が正しく動作することを確認
- [ ] 3体選択後のサマリー画面にステータスバーが表示されることを確認
- [ ] ゲームプレイ時にAIの挙動バランスが従来と大きく変わらないことを確認
