### PR TITLE
fix: スマホでステータスバーの数値変動によるレイアウトのガクつきを修正

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -11,9 +11,9 @@ html, body { width: 100%; height: 100%; overflow: hidden; font-family: 'Orbitron
 
 /* Stats bar */
 #stats-bar { display: flex; justify-content: space-around; padding: 4px 8px; background: #0a1020; border-bottom: 1px solid rgba(233,69,96,0.2); }
-.stat-item { text-align: center; font-size: 11px; line-height: 1.3; }
+.stat-item { text-align: center; font-size: 11px; line-height: 1.3; flex: 1; min-width: 0; }
 .stat-item .stat-name { opacity: 0.7; }
-.stat-item .stat-value { font-weight: bold; font-size: 13px; }
+.stat-item .stat-value { font-weight: bold; font-size: 13px; font-variant-numeric: tabular-nums; }
 .stat-item.active { background: rgba(255,255,255,0.1); border-radius: 6px; padding: 1px 6px; }
 .stat-item { cursor: pointer; border-radius: 6px; padding: 1px 6px; }
 .stat-item.viewing { outline: 2px solid #fff; outline-offset: -1px; }

--- a/js/main.js
+++ b/js/main.js
@@ -800,7 +800,7 @@ function updateStatsBar() {
     nameRow.appendChild(nameSpan);
     const valueSpan = document.createElement('div');
     valueSpan.className = 'stat-value';
-    valueSpan.textContent = remaining + 'pcs / ' + remainingSquares + 'sq';
+    valueSpan.textContent = String(remaining).padStart(2, '\u2007') + 'pcs / ' + String(remainingSquares).padStart(2, '\u2007') + 'sq';
     div.appendChild(nameRow);
     div.appendChild(valueSpan);
     div.onclick = () => toggleViewPlayer(i);


### PR DESCRIPTION
- stat-itemにflex:1を追加し均等幅レイアウトに変更
- font-variant-numeric: tabular-numsで等幅数字を使用
- 数値をfigure space(\u2007)でパディングし桁数変動時の幅変化を防止

Closes #136

https://claude.ai/code/session_01UH2Yp2VRza3XfBWYqvxJx3