### PR TITLE
Remove puzzle page entry from sitemap

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -7,12 +7,6 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://tetutetu214.com/game/kado/puzzle/</loc>
-    <lastmod>2026-04-01</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
     <loc>https://tetutetu214.com/game/kado/en/</loc>
     <lastmod>2026-04-03</lastmod>
     <changefreq>weekly</changefreq>


### PR DESCRIPTION
## Summary
Removed the sitemap entry for the puzzle page at `/game/kado/puzzle/` from the sitemap.xml file.

## Changes
- Removed the URL entry for `https://tetutetu214.com/game/kado/puzzle/` including its metadata (lastmod date, changefreq, and priority settings)

## Details
This change delists the puzzle page from the sitemap, which will prevent search engines from crawling and indexing this page. This may indicate the page is being deprecated, moved, or is no longer intended to be publicly discoverable through search engines.

https://claude.ai/code/session_01PokCtQEEmfFrfbvrneqyvp